### PR TITLE
Make sure the GetMyTrips query has a result before accessing fields

### DIFF
--- a/final/client/src/pages/profile.js
+++ b/final/client/src/pages/profile.js
@@ -28,7 +28,7 @@ export default function Profile() {
         return (
           <Fragment>
             <Header>My Trips</Header>
-            {data.me.trips.length ? (
+            {data.me && data.me.trips.length ? (
               data.me.trips.map(launch => (
                 <LaunchTile key={launch.id} launch={launch} />
               ))


### PR DESCRIPTION
I was just hit by #34. Steps to reproduce:

1. Clear your browser cache.
2. Login with a new account.
3. Click on the `Profile` menu option; this leads to a `Cannot read property 'trips' of null` error due to attempting to access fields in the `GetMyTrips` result selection set, when they aren't available. The initial response is `{ data: { me: null } }`.

I've added an extra `data.me` truthy check to fix this. Thanks!

Fixes #34.