### PR TITLE
Replace `initializers` with `cache.writeData`

### DIFF
--- a/final/client/src/index.js
+++ b/final/client/src/index.js
@@ -25,12 +25,15 @@ const client = new ApolloClient({
       'client-version': '1.0.0',
     },
   }),
-  initializers: {
-    isLoggedIn: () => !!localStorage.getItem('token'),
-    cartItems: () => [],
-  },
   resolvers,
   typeDefs,
+});
+
+cache.writeData({
+  data: {
+    isLoggedIn: !!localStorage.getItem('token'),
+    cartItems: [],
+  },
 });
 
 /**


### PR DESCRIPTION
Initializers are no longer part of the AC local state API. We're now recommending that people use `cache.writeData` directly, since it's already part of the Apollo Cache API and is more flexible.