### PR TITLE
Remove unused code in utils.js

### DIFF
--- a/final/server/src/utils.js
+++ b/final/server/src/utils.js
@@ -26,8 +26,6 @@ module.exports.paginateResults = ({
           Math.min(results.length, cursorIndex + 1 + pageSize),
         )
     : results.slice(0, pageSize);
-
-  results.slice(cursorIndex >= 0 ? cursorIndex + 1 : 0, cursorIndex >= 0);
 };
 
 module.exports.createStore = () => {

--- a/start/server/src/utils.js
+++ b/start/server/src/utils.js
@@ -26,8 +26,6 @@ module.exports.paginateResults = ({
           Math.min(results.length, cursorIndex + 1 + pageSize),
         )
     : results.slice(0, pageSize);
-
-  results.slice(cursorIndex >= 0 ? cursorIndex + 1 : 0, cursorIndex >= 0);
 };
 
 module.exports.createStore = () => {


### PR DESCRIPTION
There is a line of code after `return`, we should remove it.