### PR TITLE
Nav to start page on login

### DIFF
--- a/final/client/src/index.js
+++ b/final/client/src/index.js
@@ -6,6 +6,7 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import { HttpLink } from 'apollo-link-http';
 import { ApolloProvider, useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
+import { navigate } from "@reach/router";
 
 import Pages from './pages';
 import Login from './pages/login';
@@ -54,7 +55,11 @@ const IS_LOGGED_IN = gql`
 
 function IsLoggedIn() {
   const { data } = useQuery(IS_LOGGED_IN);
-  return data.isLoggedIn ? <Pages /> : <Login />;
+  if (data.isLoggedIn) {
+    return <Pages />;
+  }
+  navigate(`/`);  
+  return <Login />;
 }
 
 injectStyles();


### PR DESCRIPTION
When you log out and log in as a different user, the app should
take the user to the start page not the last page viewed by the
previous user.