### PR TITLE
fix typo, GraphQL operation name `login` should be `Login`

### DIFF
--- a/final/client/src/pages/login.js
+++ b/final/client/src/pages/login.js
@@ -5,7 +5,7 @@ import gql from 'graphql-tag';
 import { LoginForm, Loading } from '../components';
 
 export const LOGIN_USER = gql`
-  mutation login($email: String!) {
+  mutation Login($email: String!) {
     login(email: $email)
   }
 `;


### PR DESCRIPTION
fix typo, GraphQL operation name `login` should be `Login` in PascalCase

The same as tutorial [#709](https://github.com/apollographql/apollo/pull/709)