### PR TITLE
Add CartItem to /start to simplify tutorial

### DIFF
--- a/start/client/src/containers/cart-item.js
+++ b/start/client/src/containers/cart-item.js
@@ -1,5 +1,25 @@
 import React from 'react';
+import { useQuery } from '@apollo/react-hooks';
+import gql from 'graphql-tag';
 
-export default function CartItem() {
-  return <div />;
+import LaunchTile from '../components/launch-tile';
+import { LAUNCH_TILE_DATA } from '../pages/launches';
+
+export const GET_LAUNCH = gql`
+  query GetLaunch($launchId: ID!) {
+    launch(id: $launchId) {
+      ...LaunchTile
+    }
+  }
+  ${LAUNCH_TILE_DATA}
+`;
+
+export default function CartItem({ launchId }) {
+  const { data, loading, error } = useQuery(
+    GET_LAUNCH,
+    { variables: { launchId } }
+  );
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>ERROR: {error.message}</p>;
+  return data && <LaunchTile launch={data.launch} />;
 }


### PR DESCRIPTION
This component was never mentioned in the text tutorial.

It should probably be explained in more detail, but until then, adding
it to the starter code would give learners a better flow.

Resolves https://github.com/apollographql/apollo/issues/699