### PR TITLE
fix an error at first npm start in the tutorial of client in 5. Connect your API to a client

### DIFF
--- a/start/client/src/pages/launches.tsx
+++ b/start/client/src/pages/launches.tsx
@@ -1,11 +1,13 @@
-import React, { Fragment }  from 'react';
-import { RouteComponentProps } from '@reach/router';
+import React, { Fragment } from "react";
+import gql from "graphql-tag";
+import { RouteComponentProps } from "@reach/router";
+
+export const LAUNCH_TILE_DATA = gql``;
 
 interface LaunchesProps extends RouteComponentProps {}
 
 const Launches: React.FC<LaunchesProps> = () => {
   return <div />;
-}
+};
 
 export default Launches;
-


### PR DESCRIPTION
The page of this problem.
https://www.apollographql.com/docs/tutorial/client/#make-your-first-query

# Summary
There is an error at first `npm start` like the below.
We need to add `LAUNCH_TILE_DATA` to `src/pages/launches.tsx` to remove this error for making the tutorial better.

```
.../fullstack-tutorial/start/client/src/containers/cart-item.tsx
TypeScript error in .../fullstack-tutorial/start/client/src/containers/cart-item.tsx(6,10):
Module '".../fullstack-tutorial/start/client/src/pages/launches"' has no exported member 'LAUNCH_TILE_DATA'. Did you mean to use 'import LAUNCH_TILE_DATA from ".../fullstack-tutorial/start/client/src/pages/launches"' instead?  TS2614

    4 | 
    5 | import LaunchTile from '../components/launch-tile';
  > 6 | import { LAUNCH_TILE_DATA } from '../pages/launches';
      |          ^
    7 | import * as LaunchDetailTypes from '../pages/__generated__/LaunchDetails';
    8 | 
    9 | export const GET_LAUNCH = gql`
```

# Details
I added `LAUNCH_TILE_DATA` to `src/pages/launches.tsx`.

How do you think about this implementation?
I'd like you to check this.


This issue is also open on the repository of `apollo`.
[[Tutorial] LAUNCH_TILE_DATA definition missing when running the client for the first time #770](https://github.com/apollographql/apollo/issues/770)

