### PR TITLE
start/client: Add empty LAUNCH_TILE_DATA into launches.tsx.

### DIFF
--- a/start/client/src/pages/launches.tsx
+++ b/start/client/src/pages/launches.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment }  from 'react';
 import { RouteComponentProps } from '@reach/router';
+import gql from 'graphql-tag';
 
 interface LaunchesProps extends RouteComponentProps {}
 
@@ -7,5 +8,7 @@ const Launches: React.FC<LaunchesProps> = () => {
   return <div />;
 }
 
-export default Launches;
+export const LAUNCH_TILE_DATA = gql`
+`;
 
+export default Launches;


### PR DESCRIPTION
👋 Hey, I've noticed that `start/client` project is broken when you start application. It interrupts this stage of tutorial - https://www.apollographql.com/docs/tutorial/client/

Issue: 
![image](https://user-images.githubusercontent.com/8162439/79130562-11324280-7d9f-11ea-94a8-1076e7ff49d8.png)

Steps to reproduce:
```sh
git clone https://github.com/apollographql/fullstack-tutorial/
cd fullstack-tutorial/start/cleint
npm i
npm start
```

I've added quick fix by adding empty graphql string.