### PR TITLE
Disable launches type policy keyArgs to fix pagination

### DIFF
--- a/final/client/src/cache.ts
+++ b/final/client/src/cache.ts
@@ -11,6 +11,7 @@ export const cache: InMemoryCache = new InMemoryCache({
           return cartItemsVar();
         },
         launches: {
+          keyArgs: false,
           merge(existing, incoming) {
             let launches: Reference[] = [];
             if (existing && existing.launches) {


### PR DESCRIPTION
When launches are originally fetched, they are fetched without any pagination parameters. This means by default they're stored in the cache under a key of `launches({})`. Then when the next batch of launches is fetched through pagination, an `after` parameter is used to mark the next batch of launches to be loaded. By default, the cache will use parameters as part of the key it stores values under, which means the next batch of launches is stored under a key that looks something like `launches({"after":"1558665000"})`. When the launches merge function tries to merge previous results with new incoming results, it doesn't see any previous results when a new batch of launches is received, because each time that batch is stored under a separate cache key.

Setting `keyArgs: false` for the `launches` field policy tells the cache to ignore the `after` parameter, making sure all launches are stored under the same cache key. This helps the merge function load previous launches, and merge in the new
launches.