### PR TITLE
Update utils.js

### DIFF
--- a/start/server/src/utils.js
+++ b/start/server/src/utils.js
@@ -37,7 +37,7 @@ module.exports.createStore = () => {
   const db = new SQL('database', 'username', 'password', {
     dialect: 'sqlite',
     storage: './store.sqlite',
-    operatorsAliases,
+    operatorsAliases: 0,
     logging: false,
   });
 


### PR DESCRIPTION

Adding "operatorsAliases: 0," removes this error from the console:

[SEQUELIZE0003] DeprecationWarning: String based operators are deprecated. Please use Symbol based operators for better security, read more at https://sequelize.org/master/manual/querying.html#operators