### PR TITLE
update sqlite3 to 5.0.0

### DIFF
--- a/final/server/package.json
+++ b/final/server/package.json
@@ -22,7 +22,7 @@
     "mime": "^2.4.4",
     "nodemon": "^1.19.4",
     "sequelize": "^5.21.2",
-    "sqlite3": "^4.1.1",
+    "sqlite3": "*5.0.0",
     "uuid": "^3.3.3"
   },
   "devDependencies": {

--- a/start/server/package.json
+++ b/start/server/package.json
@@ -20,7 +20,7 @@
     "isemail": "^3.1.3",
     "nodemon": "^1.18.4",
     "sequelize": "^4.39.0",
-    "sqlite3": "^4.0.3"
+    "sqlite3": "*5.0.0"
   },
   "devDependencies": {
     "apollo-link": "^1.2.3",


### PR DESCRIPTION
Running npm install for a new clone, sqlite3 refuses to install, this should be a problem with the package. For now only version 5.0.0 works well, later and older ones refuse to install.﻿
