### PR TITLE
fix loginVariables as LoginVariables

### DIFF
--- a/final/client/src/components/login-form.tsx
+++ b/final/client/src/components/login-form.tsx
@@ -11,7 +11,7 @@ import { colors, unit } from '../styles';
 import * as LoginTypes from '../pages/__generated__/login';
 
 interface LoginFormProps {
-  login: (a: { variables: LoginTypes.loginVariables }) => void;
+  login: (a: { variables: LoginTypes.LoginVariables }) => void;
 }
 
 interface LoginFormState {


### PR DESCRIPTION
## Fix Issue #197
`LoginTypes.loginVariables` is changed as `LoginTypes.LoginVariables`.

## Before Fix
When running `cd final/client && npm i && npm start`, it shows the error message below.
```
Failed to compile.

/fullstack-tutorial/final/client/src/components/login-form.tsx
TypeScript error in /fullstack-tutorial/final/client/src/components/login-form.tsx(14,38):
Namespace '"/fullstack-tutorial/final/client/src/pages/__generated__/login"' has no exported member 'loginVariables'.  TS2694

    12 | 
    13 | interface LoginFormProps {
  > 14 |   login: (a: { variables: LoginTypes.loginVariables }) => void;
       |                                      ^
    15 | }
    16 | 
    17 | interface LoginFormState {

```

## After Fix
The client script is complied successfully when running `cd final/client && npm i && npm start`.
```
Compiled successfully!

You can now view client in the browser.

  Local:            http://localhost:3000
  On Your Network:  http://192.168.1.35:3000

Note that the development build is not optimized.
To create a production build, use npm run build.
```
